### PR TITLE
Fix video centering.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1978,11 +1978,19 @@ input.footer__signup__submit:hover {
 .node-gsb-video .file-video--preview {
   margin-bottom: 17px;
   position: relative;
-  float: left;
+}
+.pane-bundle-video .file-video--preview .content img,
+.node-gsb-video .file-video--preview .content img {
+  margin: 0 auto;
+  display: block;
 }
 .pane-bundle-video .file-video--default,
 .node-gsb-video .file-video--default {
   clear: both;
+}
+.pane-bundle-video .file-video--default .content div,
+.node-gsb-video .file-video--default .content div {
+  margin: 0 auto;
 }
 .pane-bundle-video .video-play-icon,
 .node-gsb-video .video-play-icon {

--- a/sass/revamp-design/_block-video.sass
+++ b/sass/revamp-design/_block-video.sass
@@ -21,9 +21,13 @@
   .file-video--preview
     margin-bottom: 17px
     position: relative
-    float: left
+    .content img
+      margin: 0 auto
+      display: block
   .file-video--default
     clear: both
+    .content div
+      margin: 0 auto
   .video-play-icon
     display: block
     position: absolute


### PR DESCRIPTION
https://stanfordgsb.jira.com/browse/WP-865 asks that the video and its responsive preview be centered inside its pane.

This removes the float, and adds margin: 0 auto and display: block where necessary
